### PR TITLE
Backport changes from papirus-folders 1.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# GNU make is required to run this file. To install on *BSD, run:
+#   gmake PREFIX=/usr/local install
+
 PREFIX ?= /usr
 PROGNAME := suru-plus-folders
 
@@ -18,19 +21,9 @@ uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/share/bash-completion/completions/$(PROGNAME)
 	rm -f $(DESTDIR)$(PREFIX)/share/zsh/vendor-completions/_$(PROGNAME)
 
-_get_version:
-ifndef TAG
-	$(error TAG is not defined. Pass via "make release TAG=v0.1.2")
-endif
+.PHONY: all install uninstall
 
-release: _get_version
-	git tag -f $(TAG)
-	git push origin
-	git push origin --tags
-
-undo_release: _get_version
-	-git tag -d $(TAG)
-	-git push --delete origin $(TAG)
-
-
-.PHONY: all install uninstall _get_version release undo_release
+# .BEGIN is ignored by GNU make so we can use it as a guard
+.BEGIN:
+	@head -3 Makefile
+	@false

--- a/completion/_suru-plus-folders
+++ b/completion/_suru-plus-folders
@@ -30,7 +30,7 @@ _get_themes() {
 
 	for icons_dir in "${icons_dirs[@]}"; do
 		for icon_theme in "$icons_dir"/*; do
-			[ -f "$icon_theme/places/scalable/folder-blue.svg" ] || continue
+			[ -f "$icon_theme/places/64/folder-blue.svg" ] || continue
 			_wanted icon_theme expl 'icon-theme' compadd -- "${icon_theme:t}"
 		done
 	done
@@ -46,6 +46,6 @@ _arguments -C \
 	'(-R --restore)'{-R,--restore}'[restore the last used color from the config file]' \
 	'(-l --list)'{-l,--list}'[show available colors]' \
 	'(-t --theme)'{-t,--theme}'[make changes to the specified theme]:icon-theme:_get_themes' \
-	'(-u --update-caches)'{-u,--update-caches}'[update icon caches]'
+	'(-u --update-cache)'{-u,--update-cache}'[update icon cache]'
 
 # vim: ft=zsh sw=4 ts=4

--- a/completion/suru-plus-folders
+++ b/completion/suru-plus-folders
@@ -23,7 +23,7 @@ __get_themes() {
 
 	for icons_dir in "${icons_dirs[@]}"; do
 		for icon_theme in "$icons_dir"/*; do
-			[ -f "$icon_theme/places/scalable/folder-blue.svg" ] || continue
+			[ -f "$icon_theme/places/64/folder-blue.svg" ] || continue
 			printf '%s\n' "${icon_theme##*/}"
 		done
 	done
@@ -43,7 +43,7 @@ _suru_plus_folders() {
 		-R --restore
 		-l --list
 		-t --theme
-		-u --update-caches
+		-u --update-cache
 	)
 
 	_get_comp_words_by_ref cur prev

--- a/install.sh
+++ b/install.sh
@@ -3,9 +3,9 @@
 set -e
 
 # these variables can be overwritten
-PREFIX="${PREFIX:-/usr}"
-TAG="${TAG:-master}"
-uninstall="${uninstall:-false}"
+: "${PREFIX:=/usr}"
+: "${TAG:=master}"
+: "${uninstall:=false}"
 
 bin_name="suru-plus-folders"
 gh_url="https://github.com/gusbemacbe"
@@ -13,16 +13,16 @@ gh_repo="$bin_name"
 gh_desc="Suru++ Folders"
 
 cat <<- EOF
-                                                                                                                                                                                                  
-     _____                                     ___    ___  
-    / ____|                       _      _    |__ \  / _ \ 
+
+     _____                                     ___    ___
+    / ____|                       _      _    |__ \  / _ \
    | (___   _   _  _ __  _   _  _| |_  _| |_     ) || | | |
     \___ \ | | | || '__|| | | ||_   _||_   _|   / / | | | |
     ____) || |_| || |   | |_| |  |_|    |_|    / /_ | |_| |
-   |_____/  \__,_||_|    \__,_|               |____| \___/ 
-                                                           
-                                                                 
-                                                                                                                                                                                                                                                                                                          
+   |_____/  \__,_||_|    \__,_|               |____| \___/
+
+
+
   $gh_desc
   $gh_url/$gh_repo
 
@@ -139,15 +139,18 @@ _uninstall() {
 }
 
 _install() {
+    # strip leading `v` symbol
+    tag="${TAG#v}"
+
     _msg "$msg_install"
     sudo mkdir -p "$PREFIX/bin"
-    sudo install -m 755 "$temp_dir/$gh_repo-$TAG/$bin_name" \
+    sudo install -m 755 "$temp_dir/$gh_repo-$tag/$bin_name" \
         "$PREFIX/bin/$bin_name"
     sudo mkdir -p "$PREFIX/share/bash-completion/completions"
-    sudo install -m 644 "$temp_dir/$gh_repo-$TAG/completion/$bin_name" \
+    sudo install -m 644 "$temp_dir/$gh_repo-$tag/completion/$bin_name" \
         "$PREFIX/share/bash-completion/completions"
     sudo mkdir -p "$PREFIX/share/zsh/vendor-completions"
-    sudo install -m 644 "$temp_dir/$gh_repo-$TAG/completion/_$bin_name" \
+    sudo install -m 644 "$temp_dir/$gh_repo-$tag/completion/_$bin_name" \
         "$PREFIX/share/zsh/vendor-completions"
 }
 

--- a/languages/de.md
+++ b/languages/de.md
@@ -34,13 +34,13 @@ wget -qO- https://bit.do/suru-plus-folders | sh
 Um `suru-plus-folders` auf den **BSD-Systemen** mit dem folgenden Befehl zu installieren:
 
 ```
-wget -qO- https://bit.do/suru-plus-folders | TAG=xBSD PREFIX=/usr/local sh
+wget -qO- https://bit.do/suru-plus-folders | env PREFIX=/usr/local sh
 ```
 
 ### Zum Deinstallieren
 
 ```
-wget -qO- https://bit.do/suru-plus-folders | uninstall=true sh
+wget -qO- https://bit.do/suru-plus-folders | env uninstall=true sh
 ```
 
 ## Arch Linux-basierte Distributionen
@@ -69,7 +69,7 @@ Einige Verwendungsbeispiele:
     ```
 - Der vorige verwendeten Farbe aus einer Konfigurationsdatei wiederherstellen:
     ```
-    suru-plus-folders -R
+    suru-plus-folders -Ru
     ```
 
 ## Wichtiger Vorschlag!

--- a/languages/english.md
+++ b/languages/english.md
@@ -33,13 +33,13 @@ wget -qO- https://bit.do/suru-plus-folders | sh
 To install `suru-plus-folders` on **BSD systems** using the following command:
 
 ```
-wget -qO- https://bit.do/suru-plus-folders | TAG=xBSD PREFIX=/usr/local sh
+wget -qO- https://bit.do/suru-plus-folders | env PREFIX=/usr/local sh
 ```
 
 ### Uninstalling
 
 ```
-wget -qO- https://bit.do/suru-plus-folders | uninstall=true sh
+wget -qO- https://bit.do/suru-plus-folders | env uninstall=true sh
 ```
 
 ## Arch-based distributions
@@ -68,7 +68,7 @@ Some examples of use:
     ```
 - Restore the last used color from a config file:
     ```
-    suru-plus-folders -R
+    suru-plus-folders -Ru
     ```
 
 ## Important advice!

--- a/languages/es.md
+++ b/languages/es.md
@@ -33,13 +33,13 @@ wget -qO- https://bit.do/suru-plus-folders | sh
 Para instalar `suru-plus-folders` en los **sistemas de BSD**, utilizando el siguiente comando:
 
 ```
-wget -qO- https://bit.do/suru-plus-folders | TAG=xBSD PREFIX=/usr/local sh
+wget -qO- https://bit.do/suru-plus-folders | env PREFIX=/usr/local sh
 ```
 
 ### Desinstalando
 
 ```
-wget -qO- https://bit.do/suru-plus-folders | uninstall=true sh
+wget -qO- https://bit.do/suru-plus-folders | env uninstall=true sh
 ```
 
 ## Distribuciones basadas en Arch
@@ -68,7 +68,7 @@ Algunos ejemplos de utilización:
     ```
 - Restaurar el último color utilizado de un archivo de configuración:
     ```
-    suru-plus-folders -R
+    suru-plus-folders -Ru
     ```
 
 ## ¡Consejo importante!

--- a/languages/fr.md
+++ b/languages/fr.md
@@ -33,13 +33,13 @@ wget -qO- https://bit.do/suru-plus-folders | sh
 Pour installer `suru-plus-folders` sur **les systèmes de BSD**, en utilisant la commande suivante :
 
 ```
-wget -qO- https://bit.do/suru-plus-folders | TAG=xBSD PREFIX=/usr/local sh
+wget -qO- https://bit.do/suru-plus-folders | env PREFIX=/usr/local sh
 ```
 
 ### Désintaller
 
 ```
-wget -qO- https://bit.do/suru-plus-folders | uninstall=true sh
+wget -qO- https://bit.do/suru-plus-folders | env uninstall=true sh
 ```
 
 ## Distributions basées sur Arch Linux
@@ -68,7 +68,7 @@ Quelques exemples d'utilisation :
     ```
 - Restaurer la dernière couleur utilisée à partir d'un fichier de configuration:
     ```
-    suru-plus-folders -R
+    suru-plus-folders -Ru
     ```
 
 ## Avis important !

--- a/languages/it.md
+++ b/languages/it.md
@@ -33,13 +33,13 @@ wget -qO- https://bit.do/suru-plus-folders | sh
 Per installare `suru-plus-folders` sui **sistemi BSD**, utilizzando il seguente comando:
 
 ```
-wget -qO- https://bit.do/suru-plus-folders | TAG=xBSD PREFIX=/usr/local sh
+wget -qO- https://bit.do/suru-plus-folders | env PREFIX=/usr/local sh
 ```
 
 ### Disinstallando
 
 ```
-wget -qO- https://bit.do/suru-plus-folders | uninstall=true sh
+wget -qO- https://bit.do/suru-plus-folders | env uninstall=true sh
 ```
 
 ## Distribuzioni basate su Arch Linux
@@ -68,7 +68,7 @@ Alcuni esempi di utilizzo:
     ```
 - Ripristina l'ultimo colore utilizzato da un file di configurazione:
     ```
-    suru-plus-folders -R
+    suru-plus-folders -Ru
     ```
 
 ## Informazioni importanti!

--- a/languages/nl.md
+++ b/languages/nl.md
@@ -33,13 +33,13 @@ wget -qO- https://bit.do/suru-plus-folders | sh
 Om te installeren `suru-plus-folders` op **BSD-systemen** met een volgende opdracht:
 
 ```
-wget -qO- https://bit.do/suru-plus-folders | TAG=xBSD PREFIX=/usr/local sh
+wget -qO- https://bit.do/suru-plus-folders | env PREFIX=/usr/local sh
 ```
 
 ### Uninstalling
 
 ```
-wget -qO- https://bit.do/suru-plus-folders | uninstall=true sh
+wget -qO- https://bit.do/suru-plus-folders | env uninstall=true sh
 ```
 
 ## Arch Linux-gebaseerde distributies
@@ -68,7 +68,7 @@ Sommige voorbeelden van gebruik:
     ```
 - De laatste gebruikte kleur vanuit een configuratiebestand herstellen:
     ```
-    suru-plus-folders -R
+    suru-plus-folders -Ru
     ```
 
 ## Belangrijk advies!

--- a/languages/pt_BR.md
+++ b/languages/pt_BR.md
@@ -33,13 +33,13 @@ wget -qO- https://bit.do/suru-plus-folders | sh
 Para instalar `suru-plus-folders` nos **sistemas BSD**, usando o comando seguinte:
 
 ```
-wget -qO- https://bit.do/suru-plus-folders | TAG=xBSD PREFIX=/usr/local sh
+wget -qO- https://bit.do/suru-plus-folders | env PREFIX=/usr/local sh
 ```
 
 ### Desinstalando
 
 ```
-wget -qO- https://bit.do/suru-plus-folders | uninstall=true sh
+wget -qO- https://bit.do/suru-plus-folders | env uninstall=true sh
 ```
 
 ## Distribuições baseadas em Arch
@@ -68,7 +68,7 @@ Alguns exemplos de uso:
     ```
 - Restaurar a última cor usada de um arquivo de configuração:
     ```
-    suru-plus-folders -R
+    suru-plus-folders -Ru
     ```
 
 ## Aviso importante!

--- a/languages/pt_PT.md
+++ b/languages/pt_PT.md
@@ -33,13 +33,13 @@ wget -qO- https://bit.do/suru-plus-folders | sh
 Para instalar `suru-plus-folders` nos **sistemas BSD**, utilizando comando seguinte:
 
 ```
-wget -qO- https://bit.do/suru-plus-folders | TAG=xBSD PREFIX=/usr/local sh
+wget -qO- https://bit.do/suru-plus-folders | env PREFIX=/usr/local sh
 ```
 
 ### Desinstalando
 
 ```
-wget -qO- https://bit.do/suru-plus-folders | uninstall=true sh
+wget -qO- https://bit.do/suru-plus-folders | env uninstall=true sh
 ```
 
 ## Distribuições baseadas em Arch
@@ -68,7 +68,7 @@ Alguns exemplos de utilização:
     ```
 - Restaurar a última cor utilizada a partir dum ficheiro de configuração:
     ```
-    suru-plus-folders -R
+    suru-plus-folders -Ru
     ```
 
 ## Advertência importante!

--- a/suru-plus-folders
+++ b/suru-plus-folders
@@ -18,8 +18,8 @@ if test -z "$BASH_VERSION"; then
 	exit 1
 fi
 
-if (( BASH_VERSINFO[0] * 10 + BASH_VERSINFO[1] < 42 )); then
-	printf "Error: this script requires bash version >= 4.2\n" >&2
+if (( BASH_VERSINFO[0] * 10 + BASH_VERSINFO[1] < 40 )); then
+	printf "Error: this script requires bash version >= 4.0\n" >&2
 	exit 1
 fi
 
@@ -30,11 +30,10 @@ set -o errexit \
 
 readonly THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 readonly PROGNAME="$(basename "${BASH_SOURCE[0]}")"
-readonly VERSION="0.0.7"
+readonly VERSION="1.0.0"
 readonly -a ARGS=("$@")
 
 msg() {
-	[ "$TERM" != "dumb" ] || return 0
 	printf "%s: %b\n" "$PROGNAME" "$*" >&2
 }
 
@@ -55,10 +54,6 @@ _exit() {
 fatal() {
 	err "$@"
 	exit 1
-}
-
-opt_err() {
-	fatal "only one operation may be used at a time."
 }
 
 usage() {
@@ -93,19 +88,21 @@ _is_root_user() {
 	return 1
 }
 
-_is_system_dir() {
-	# if $THEME_DIR begins with $HOME
+_is_user_dir() {
+	[ -n "$HOME" ] || return 1
+
+	# if $THEME_DIR is placed in home dir
 	if [ -z "${THEME_DIR##"$HOME"/*}" ]; then
-		return 1
+		return 0
 	fi
 
-	return 0
+	return 1
 }
 
 _is_valid_color() {
 	local color="$1"
 
-	eval "$(get_colors)"
+	eval "$(declare_colors)"
 
 	for i in "${colors[@]}"; do
 		[ "$i" == "$color" ] || continue
@@ -115,7 +112,7 @@ _is_valid_color() {
 	return 1
 }
 
-get_colors() {
+declare_colors() {
 	local color=''
 	local -a colors=()
 	local -a valid_colors=("black" "blue" "bluegrey" "brown" "cyan"
@@ -132,11 +129,11 @@ get_colors() {
 	declare -p colors
 }
 
-get_current_color() {
+declare_current_color() {
 	local icon_file icon_name current_color=''
 
 	icon_file=$(readlink -f "$THEME_DIR/places/64/folder.svg")
-	icon_name=$(basename -s .svg "$icon_file")
+	icon_name=$(basename "$icon_file" .svg)
 	current_color="${icon_name##*-}"
 
 	declare -p current_color
@@ -170,19 +167,27 @@ get_theme_dir() {
 }
 
 get_user() {
-	local user user_dir
+	local user=''
 
 	if [ -n "$PKEXEC_UID" ]; then
 		user="$(id -nu "$PKEXEC_UID")"
 	elif [ -n "$SUDO_USER" ]; then
 		user="$SUDO_USER"
+	elif [ -n "$LOGNAME" ]; then
+		user="$LOGNAME"
 	else
-		user="$USER"
+		user="$(id -nu)"
 	fi
 
-	user_dir="$(getent passwd "$user" | awk -F: '{print $6}')"
+	printf '%s' "$user"
+}
 
-	declare -p user user_dir
+get_user_home() {
+	local user
+
+	user="$(get_user)"
+
+	getent passwd "$user" | awk -F: '{print $(NF-1)}'
 }
 
 config() {
@@ -190,10 +195,10 @@ config() {
 	local config_dir
 	local config_file
 
-	if _is_system_dir; then
-		config_dir="/var/lib/$PROGNAME"
-	else
+	if _is_user_dir; then
 		config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/$PROGNAME"
+	else
+		config_dir="/var/lib/$PROGNAME"
 	fi
 
 	config_file="$config_dir/keep"
@@ -247,30 +252,32 @@ config() {
 }
 
 change_color() {
-	[ -n "$1" ] || return 1
+	local color="${1:?${FUNCNAME[-1]}: color is not set}"
+	local size prefix file_path file_name symlink_path
+	local -a sizes=(64)
+	local -a prefixes=("folder-$color" "user-$color")
 
-	local color="$1"
-	local sizes_regex="(64)"
-	local icons_regex="(folder|user)-$color"
-	local file target symlink
+	for size in "${sizes[@]}"; do
+		for prefix in "${prefixes[@]}"; do
+			for file_path in "$THEME_DIR/places/$size/$prefix"{-*,}.svg; do
+				[ -f "$file_path" ] || continue  # is a file
+				[ -L "$file_path" ] && continue  # is not a symlink
 
-	# verbose "Changing color of folders to '$color' ..."
-	find -L "$THEME_DIR" -regextype posix-extended \
-		-regex ".*/places/${sizes_regex}/${icons_regex}.*" \
-		-print0 | while read -r -d $'\0' file; do
+				file_name="${file_path##*/}"
+				symlink_path="${file_path/-$color/}"  # remove color suffix
 
-		target="$(basename "$file")"
-		symlink="${file/-$color/}"
-
-		ln -sf "$target" "$symlink" || fatal "cannot create '$symlink' symlink"
+				ln -sf "$file_name" "$symlink_path" \
+					|| fatal "Fail to create '$symlink_path' symlink"
+			done
+		done
 	done
 }
 
 list_colors() {
 	local color='' prefix=''
 
-	eval "$(get_colors)"
-	eval "$(get_current_color)"
+	eval "$(declare_colors)"
+	eval "$(declare_current_color)"
 
 	for color in "${colors[@]}"; do
 		if [ "$current_color" == "$color" ]; then
@@ -285,7 +292,7 @@ list_colors() {
 
 do_change_color() {
 	_is_valid_color "$SELECTED_COLOR" \
-		|| fatal "'$SELECTED_COLOR' is not a valid color"
+		|| fatal "Unable to find '$SELECTED_COLOR' color in '$THEME_NAME'"
 
 	verify_privileges
 
@@ -300,7 +307,7 @@ do_revert_default() {
 	verify_privileges
 
 	msg "Restoring default folder color for '$THEME_NAME' ..."
-	change_color "${DEFAULT_COLORS[$THEME_NAME]}"
+	change_color "${DEFAULT_COLORS[$THEME_NAME]:-blue}"
 	config --new
 	update_icon_cache
 }
@@ -312,34 +319,33 @@ do_restore_color() {
 		THEME_NAME="$(config --get theme)"
 		saved_color="$(config --get color)"
 	else
-		_exit "Config file not found."
+		_exit "Unable to find config file."
 	fi
 
-	THEME_DIR="$(get_theme_dir)" || _exit "'$THEME_NAME' not found."
+	THEME_DIR="$(get_theme_dir)" \
+		|| _exit "Unable to find '$THEME_NAME' icon theme."
 
-	if [ -z "$saved_color" ]; then
-		_exit "cannot get color from a config file."
-	elif _is_valid_color "$saved_color"; then
-		verify_privileges
+	_is_valid_color "$saved_color" \
+		|| _exit "Unable to find '$saved_color' color in '$THEME_NAME'."
 
-		change_color "$saved_color"
-		msg "'$saved_color' color of the folders has been restored."
-	else
-		_exit "cannot restore '$saved_color' color of folders."
-	fi
+	verify_privileges
+
+	change_color "$saved_color"
+	msg "'$saved_color' color of the folders has been restored."
 }
 
 delete_icon_caches() {
-	local icon_cache=''
+	local icon_cache user='' user_home=''
 
-	eval "$(get_user)"
+	user="$(get_user)"
+	user_home="$(get_user_home)"
 
 	declare -a icon_caches=(
 		# KDE 5 icon caches
-		"$user_dir/.cache/icon-cache.kcache"
+		"$user_home/.cache/icon-cache.kcache"
 		"/var/tmp/kdecache-$user/icon-cache.kcache"
 		# KDE 4 icon caches
-		"$user_dir/.kde4/cache-$(hostname)/icon-cache.kcache"
+		"$user_home/.kde4/cache-$(hostname)/icon-cache.kcache"
 	)
 
 	verbose "Deleting icon caches ..."
@@ -352,13 +358,13 @@ delete_icon_caches() {
 update_icon_cache() {
 	delete_icon_caches
 
-	verbose "Rebuilding icon cache ..."
+	verbose "Rebuilding icon cache for '$THEME_NAME' ..."
 	gtk-update-icon-cache -qf "$THEME_DIR" || true
 }
 
 verify_privileges() {
-	_is_root_user  && return 0
-	_is_system_dir || return 0
+	_is_root_user && return 0
+	_is_user_dir  && return 0
 
 	verbose "This operation requires root privileges."
 
@@ -376,15 +382,15 @@ parse_args() {
 	# Translate --gnu-long-options to -g (short options)
 	for arg; do
 		case "$arg" in
-			--help)          args+=( -h ) ;;
-			--list)          args+=( -l ) ;;
-			--theme)         args+=( -t ) ;;
-			--update-cache)  args+=( -u ) ;;
-			--verbose)       args+=( -v ) ;;
-			--color)         args+=( -C ) ;;
-			--default)       args+=( -D ) ;;
-			--restore)       args+=( -R ) ;;
-			--version)       args+=( -V ) ;;
+			--help)           args+=( -h ) ;;
+			--list)           args+=( -l ) ;;
+			--theme)          args+=( -t ) ;;
+			--update-caches)  args+=( -u ) ;;
+			--verbose)        args+=( -v ) ;;
+			--color|--colour) args+=( -C ) ;;
+			--default)        args+=( -D ) ;;
+			--restore)        args+=( -R ) ;;
+			--version)        args+=( -V ) ;;
 			--[0-9a-Z]*)
 				err "illegal option -- '$arg'"
 				usage 128
@@ -398,19 +404,14 @@ parse_args() {
 
 	while getopts ":C:DRlt:uvVh" opt; do
 		case "$opt" in
-			C ) [ -z "$OPERATION" ] || opt_err
-				OPERATION="change-color"
+			C ) OPERATIONS+=("change-color")
 				SELECTED_COLOR="$OPTARG"
 				;;
-			D ) [ -z "$OPERATION" ] || opt_err
-				OPERATION="revert-default"
-				;;
-			R ) [ -z "$OPERATION" ] || opt_err
-				OPERATION="restore-color"
-				;;
-			l ) OPTIONS+=("list-colors") ;;
+			D ) OPERATIONS+=("revert-default") ;;
+			R ) OPERATIONS+=("restore-color") ;;
+			l ) OPERATIONS+=("list-colors") ;;
 			t ) THEME_NAME="$OPTARG" ;;
-			u ) OPTIONS+=("update-icon-cache") ;;
+			u ) OPERATIONS+=("update-icon-cache") ;;
 			v ) VERBOSE=1 ;;
 			V ) printf "%s %s\n" "$PROGNAME" "$VERSION"
 				exit 0
@@ -439,29 +440,31 @@ main() {
 	declare THEME_NAME="${THEME_NAME:-Suru++}"
 	declare -i VERBOSE="${VERBOSE:-0}"
 	declare -A DEFAULT_COLORS=(
-	        ['Suru++ 20']='blue'
+		['Suru++ 20']='blue'
 		['Suru++']='blue'
 		['suru-plus']='blue'
 		['suru-plus-master']='blue'
 	)
 
-	declare OPERATION=''
 	declare SELECTED_COLOR=''
-	declare -a OPTIONS=()
+	declare -a OPERATIONS=()
 
 	parse_args "${ARGS[@]}"
 
 	THEME_DIR="$(get_theme_dir)" \
-		|| fatal "fail to find '$THEME_NAME' icon theme."
+		|| fatal "Fail to find '$THEME_NAME' icon theme."
 
-	case "$OPERATION" in
-		change-color)   do_change_color   ;;
-		revert-default) do_revert_default ;;
-		restore-color)  do_restore_color  ;;
-	esac
-
-	for option in "${OPTIONS[@]}"; do
-		case "$option" in
+	for operation in "${OPERATIONS[@]}"; do
+		case "$operation" in
+			change-color)
+				do_change_color
+				;;
+			revert-default)
+				do_revert_default
+				;;
+			restore-color)
+				do_restore_color
+				;;
 			list-colors)
 				cat <<- EOF
 				List of available colors:


### PR DESCRIPTION
- Reduced requirements to bash ≥ 4.0 and busybox utilities
- Replaced find command to for-loop statement
- Added `--colour` as a hidden alias for `--color`
- Revert to default color works for unknown icon themes
- Changed several error messages to make it more user-friendly
- BSD and Linux versions of papirus-folders were merged into one
- Fixed bug with invalid symlinks that appears when changing color to
blue
- Fixed `find: ‘...’: No such file or directory` crash
- Fixed restore saved color when $HOME is unset
- Fixed zsh completion for a case when icons_dir is a symlink
- Improved installation scripts

**NOTE:** Recommended to reinstall suru-plus to override changes committed by the previous version of suru-plus-folders.


[List of all changes](https://github.com/PapirusDevelopmentTeam/papirus-folders/compare/v0.0.7...master)